### PR TITLE
파일 업로드

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,11 @@ dependencies {
     //redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-cache'
+
+
+    // aws-java-sdk-s3
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/kr/bit/animalinc/config/BucketConfig.java
+++ b/src/main/java/kr/bit/animalinc/config/BucketConfig.java
@@ -1,0 +1,36 @@
+package kr.bit.animalinc.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class BucketConfig {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Value("${cloud.aws.s3.endpoint}")
+    private String endpoint;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials awsCreds = new BasicAWSCredentials(accessKey, secretKey);
+        return (AmazonS3Client) AmazonS3ClientBuilder.standard()
+                .withCredentials(new AWSStaticCredentialsProvider(awsCreds))
+                .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(endpoint, region))
+                .build();
+    }
+
+}

--- a/src/main/java/kr/bit/animalinc/controller/board/BoardController.java
+++ b/src/main/java/kr/bit/animalinc/controller/board/BoardController.java
@@ -1,5 +1,13 @@
 package kr.bit.animalinc.controller.board;
 
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.*;
+import kr.bit.animalinc.config.BucketConfig;
 import kr.bit.animalinc.dto.board.BoardWriteDTO;
 import kr.bit.animalinc.entity.board.BoardCommunity;
 import kr.bit.animalinc.service.board.BoardService;
@@ -8,9 +16,14 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.security.Principal;
-import java.util.Map;
+import java.util.*;
 
 @RestController
 @RequestMapping("/api/board")
@@ -19,6 +32,7 @@ import java.util.Map;
 public class BoardController {
 
     private final BoardService boardService;
+    private final BucketConfig bucketConfig;
 
     @GetMapping("/test")
     public ResponseEntity<Map<String,Object>> testBoardController() {
@@ -77,4 +91,8 @@ public class BoardController {
 
         return ResponseEntity.ok(Map.of("data", "deleted"));
     }
+
+
+
+
 }

--- a/src/main/java/kr/bit/animalinc/util/UploadRestController.java
+++ b/src/main/java/kr/bit/animalinc/util/UploadRestController.java
@@ -1,0 +1,50 @@
+package kr.bit.animalinc.util;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.*;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class UploadRestController {
+
+    private final AmazonS3Client amazonS3Client;
+
+    @PostMapping("/upload/img")
+    public ResponseEntity<?> uploadImage(@RequestParam("file") MultipartFile file,
+                                         @RequestParam("folderName") String folderName) throws IOException {
+
+        if (!file.isEmpty()) {
+            String[] splitName = file.getOriginalFilename().split("\\.");
+            String uploadName = folderName + "/" + splitName[0] + "_" + UUID.randomUUID().toString() + "." + splitName[1];
+
+            amazonS3Client.putObject(new PutObjectRequest("aniinc", uploadName, file.getInputStream(), null)
+                    .withCannedAcl(CannedAccessControlList.PublicRead));
+
+            String url = amazonS3Client.getUrl("aniinc", uploadName).toString();
+            System.out.println(url);
+
+            Map<String, String> map = new HashMap<>();
+            map.put("url", url);
+            map.put("upLoadFilename", uploadName);
+
+            return ResponseEntity.ok(map);
+        } else {
+            System.out.println();
+            return ResponseEntity.badRequest().body("File is empty");
+        }
+    }
+}

--- a/src/main/java/kr/bit/animalinc/util/UploadService.java
+++ b/src/main/java/kr/bit/animalinc/util/UploadService.java
@@ -1,0 +1,37 @@
+package kr.bit.animalinc.util;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.*;
+
+@Service
+@RequiredArgsConstructor
+public class UploadService {
+    private final AmazonS3Client amazonS3Client;
+
+    public String uploadImage(MultipartFile file, String folderName) throws IOException {
+        if (!file.isEmpty()) {
+            String[] splitName = file.getOriginalFilename().split("\\.");
+            String uploadName = folderName + "/" + splitName[0] + "_" + UUID.randomUUID().toString() + "." + splitName[1];
+
+            amazonS3Client.putObject(new PutObjectRequest("aniinc", uploadName, file.getInputStream(), null)
+                    .withCannedAcl(CannedAccessControlList.PublicRead));
+
+            String url = amazonS3Client.getUrl("aniinc", file.getOriginalFilename()).toString();
+            System.out.println(url);
+
+            return uploadName;
+        } else {
+            return "file is empty";
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,8 +35,21 @@ spring:
         starttls.enable: true
         starttls.required: true
 
-  redis:
-    host: localhost
-    port: 6379
+#  redis:
+#    host: localhost
+#    port: 6379
   cache:
     type: redis
+
+cloud:
+  aws:
+    credentials:
+      access-key: B9A0F1108DE5EDB2C7FD
+      secret-key: 51A88C5C7068C7A9B2868B1C7C0B5F68FAB6FA46
+    stack:
+      auto: false
+    region:
+      static: kr-standard
+    s3:
+      endpoint: https://kr.object.ncloudstorage.com
+      bucket: aniinc

--- a/src/test/java/kr/bit/animalinc/util/UploadOSTests.java
+++ b/src/test/java/kr/bit/animalinc/util/UploadOSTests.java
@@ -1,0 +1,23 @@
+package kr.bit.animalinc.util;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+
+@SpringBootTest
+@Slf4j
+@RequiredArgsConstructor
+public class UploadOSTests {
+
+    private final UploadService uploadService;
+
+    @Test
+    public void testUploadService() {
+
+    }
+}


### PR DESCRIPTION
# NCP object storage에 파일 업로드 가능
- util의 Rest Controller, Service 생성됨
- 컨트롤러는 file: {파일}, folderName: 'images아님 다른 폴더명'으로 보내면됨 리턴으로는 파일명과 url 알려줌
- 서비스도 multipartfile과 folder명 순으로 파라미터 넣어서 보내면 파일명 리턴  